### PR TITLE
Handle team member save failures and surface in admin UI

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -452,7 +452,11 @@ function startUpload(task) {
                 const fd = new FormData(form);
                 fd.append('ajax', '1');
                 fetch('save.php', { method: 'POST', body: fd })
-                  .then(r => r.text()).then(txt => { let d=null; try{ d=JSON.parse(txt);}catch(e){} if(!d||d.status!=='success'){ showToast(d&&d.message?d.message:'Opslaan mislukt', false); return; }
+                  .then(r => r.text()).then(txt => {
+                    let d = null; try { d = JSON.parse(txt); } catch (e) {}
+                    if (!d) { showToast('Opslaan mislukt', false); return; }
+                    if (d.status === 'error') { showToast(d.message || 'Opslaan mislukt', false); return; }
+                    if (d.status !== 'success') { showToast('Opslaan mislukt', false); return; }
                     showToast('Opgeslagen', true);
                     // Post-save UX tweaks for specific actions
                     const action = actionName;

--- a/save.php
+++ b/save.php
@@ -490,7 +490,11 @@ case 'add_theme':
             $id = uniqid('tm_', true);
             $data['members'][] = ['id' => $id, 'name' => $name, 'role' => $role, 'appointment_url' => $appt, 'image' => '', 'webp' => ''];
             @mkdir(dirname($teamFilePath), 0755, true);
-            saveJsonFile($teamFilePath, $data);
+            $saved = saveJsonFile($teamFilePath, $data);
+            if ($saved === false) {
+                if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt']); }
+                exit;
+            }
             if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'success','member'=>['id'=>$id,'name'=>$name,'role'=>$role,'appointment_url'=>$appt]]); exit; }
         }
         break;
@@ -509,7 +513,11 @@ case 'add_theme':
                 }
             }
             unset($m);
-            saveJsonFile($teamFilePath, $data);
+            $saved = saveJsonFile($teamFilePath, $data);
+            if ($saved === false) {
+                if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt']); }
+                exit;
+            }
             if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'success','id'=>$id]); exit; }
         }
         break;
@@ -532,7 +540,11 @@ case 'add_theme':
                         break;
                     }
                 }
-                saveJsonFile($teamFilePath, $data);
+                $saved = saveJsonFile($teamFilePath, $data);
+                if ($saved === false) {
+                    if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt']); }
+                    exit;
+                }
                 if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'success','id'=>$id]); exit; }
             }
         }


### PR DESCRIPTION
## Summary
- Check `saveJsonFile` result for team member add/update/delete actions and return error JSON on failure.
- Show toast error messages in the admin interface when the backend responds with `status: 'error'`.

## Testing
- `php -l save.php`
- `node --check admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb50432c83208b90778618198caf