### PR TITLE
Log JSON save failures to /data/logs/app.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Project Overview
+
+This project powers the Jeroen website admin and API.
+
+## Logging
+
+All errors encountered while saving JSON data are written to `/data/logs/app.log` using PHP's `error_log`.
+Ensure the `/data/logs` directory is writable on deployment to allow monitoring and troubleshooting.

--- a/admin.php
+++ b/admin.php
@@ -58,7 +58,7 @@ if (!empty($teamData['members']) && is_array($teamData['members'])) {
         if (empty($m['id'])) { $m['id'] = uniqid('tm_', true); $changed = true; }
     }
     unset($m);
-    if ($changed) { @file_put_contents($teamFilePath, json_encode($teamData, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE), LOCK_EX); }
+    if ($changed) { saveJsonFile($teamFilePath, $teamData); }
 }
 $pass_status = $_GET['password_change'] ?? '';
 $mailbox_status = $_GET['mailbox_update'] ?? '';

--- a/helpers.php
+++ b/helpers.php
@@ -1,6 +1,20 @@
 <?php
 
 /**
+ * Schrijf een bericht naar het applicatielog.
+ *
+ * @param string $message Het logbericht.
+ */
+function appLog(string $message): void {
+    $logFile = '/data/logs/app.log';
+    $dir = dirname($logFile);
+    if (!is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    error_log('[' . date('c') . '] ' . $message . PHP_EOL, 3, $logFile);
+}
+
+/**
  * Laadt en decodeert een JSON-bestand.
  * @param string $filePath Het pad naar het JSON-bestand.
  * @return array De gedecodeerde data of een lege array bij een fout.
@@ -23,6 +37,8 @@ function saveJsonFile(string $filePath, array $data): bool {
     $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
     // Gebruik LOCK_EX om te voorkomen dat meerdere processen tegelijk schrijven.
     if (file_put_contents($filePath, $json, LOCK_EX) === false) {
+        $error = error_get_last()['message'] ?? 'Unknown error';
+        appLog("Failed to save JSON file {$filePath}: {$error}");
         return false;
     }
     return true;

--- a/reset.php
+++ b/reset.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once 'config.php';
+require_once 'helpers.php';
 
 $tokensFile = DATA_DIR . '/reset_tokens.json';
 
@@ -8,7 +9,7 @@ function loadTokens($file) {
     return file_exists($file) ? (json_decode(file_get_contents($file), true) ?: []) : [];
 }
 function saveTokens($file, $tokens) {
-    @file_put_contents($file, json_encode($tokens, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE));
+    saveJsonFile($file, $tokens);
 }
 
 $token = $_GET['token'] ?? '';

--- a/save.php
+++ b/save.php
@@ -130,7 +130,7 @@ switch ($action) {
             'email' => $email,
             'message' => $message
         ];
-        @file_put_contents(MESSAGES_FILE, json_encode($messages, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE));
+        saveJsonFile(MESSAGES_FILE, $messages);
 
         // Send email
         $subject = 'Nieuw bericht via website';
@@ -215,7 +215,7 @@ switch ($action) {
             'pricing' => $pricingTitle,
             'message' => $message
         ];
-        @file_put_contents(MESSAGES_FILE, json_encode($messages, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE));
+        saveJsonFile(MESSAGES_FILE, $messages);
 
         // Build mail
         $subject = 'Nieuw bericht via website';
@@ -268,7 +268,7 @@ switch ($action) {
         // Prune expired
         $tokens = array_values(array_filter($tokens, function($t){ return isset($t['expires']) && $t['expires'] > time() && empty($t['used']); }));
         $tokens[] = ['hash' => $hash, 'expires' => $expires, 'created' => time(), 'used' => false];
-        @file_put_contents($tokensFile, json_encode($tokens, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE));
+        saveJsonFile($tokensFile, $tokens);
 
         // Build absolute reset link
         $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';


### PR DESCRIPTION
## Summary
- Add `appLog()` helper writing to `/data/logs/app.log`
- Log JSON persistence failures through `saveJsonFile()` and replace direct writes
- Document log file location for deployment monitoring

## Testing
- `php -l helpers.php`
- `php -l admin.php`
- `php -l reset.php`
- `php -l save.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9ed7356d483209ac67ed4efd0f034