### PR TITLE
Ensure team data directory exists before saving

### DIFF
--- a/save.php
+++ b/save.php
@@ -513,7 +513,12 @@ case 'add_theme':
                 }
             }
             unset($m);
-            $saved = saveJsonFile($teamFilePath, $data);
+            @mkdir(dirname($teamFilePath), 0755, true);
+            if (is_dir(dirname($teamFilePath))) {
+                $saved = saveJsonFile($teamFilePath, $data);
+            } else {
+                $saved = false;
+            }
             if ($saved === false) {
                 if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt']); }
                 exit;
@@ -540,7 +545,12 @@ case 'add_theme':
                         break;
                     }
                 }
-                $saved = saveJsonFile($teamFilePath, $data);
+                @mkdir(dirname($teamFilePath), 0755, true);
+                if (is_dir(dirname($teamFilePath))) {
+                    $saved = saveJsonFile($teamFilePath, $data);
+                } else {
+                    $saved = false;
+                }
                 if ($saved === false) {
                     if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt']); }
                     exit;


### PR DESCRIPTION
## Summary
- Ensure the team data directory is created before updates or deletions.
- Only save the team data file when its directory exists, keeping existing error handling.

## Testing
- `php -l save.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9ed70e8ec8320aca0fee36aa78ebf