### PR TITLE
Improve JSON save error reporting

### DIFF
--- a/save.php
+++ b/save.php
@@ -364,10 +364,11 @@ case 'add_theme':
             $portfolioData['themes'][$themeName]['images'][$photoIndex]['description'] = $_POST['description'] ?? '';
             $portfolioData['themes'][$themeName]['images'][$photoIndex]['featured'] = isset($_POST['featured']);
             $portfolioData['themes'][$themeName]['images'][$photoIndex]['alt'] = $_POST['alt'] ?? '';
-            if (saveJsonFile($portfolioFilePath, $portfolioData)) {
+            $result = saveJsonFile($portfolioFilePath, $portfolioData);
+            if ($result['ok']) {
                 echo json_encode(['status' => 'success', 'message' => 'Foto details opgeslagen.']);
             } else {
-                echo json_encode(['status' => 'error', 'message' => 'Kon data niet opslaan.']);
+                echo json_encode(['status' => 'error', 'message' => 'Kon data niet opslaan.', 'error' => $result['error']]);
             }
             exit;
         }
@@ -491,8 +492,8 @@ case 'add_theme':
             $data['members'][] = ['id' => $id, 'name' => $name, 'role' => $role, 'appointment_url' => $appt, 'image' => '', 'webp' => ''];
             @mkdir(dirname($teamFilePath), 0755, true);
             $saved = saveJsonFile($teamFilePath, $data);
-            if ($saved === false) {
-                if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt']); }
+            if (!$saved['ok']) {
+                if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt','error'=>$saved['error']]); }
                 exit;
             }
             if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'success','member'=>['id'=>$id,'name'=>$name,'role'=>$role,'appointment_url'=>$appt]]); exit; }
@@ -514,8 +515,8 @@ case 'add_theme':
             }
             unset($m);
             $saved = saveJsonFile($teamFilePath, $data);
-            if ($saved === false) {
-                if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt']); }
+            if (!$saved['ok']) {
+                if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt','error'=>$saved['error']]); }
                 exit;
             }
             if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'success','id'=>$id]); exit; }
@@ -541,8 +542,8 @@ case 'add_theme':
                     }
                 }
                 $saved = saveJsonFile($teamFilePath, $data);
-                if ($saved === false) {
-                    if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt']); }
+                if (!$saved['ok']) {
+                    if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'error','message'=>'Opslaan mislukt','error'=>$saved['error']]); }
                     exit;
                 }
                 if ($isAjax) { header('Content-Type: application/json'); echo json_encode(['status'=>'success','id'=>$id]); exit; }
@@ -735,10 +736,11 @@ case 'add_theme':
                 }
             }
             $portfolioData['themes'][$themeName]['images'] = $newOrderedImages;
-            if (saveJsonFile($portfolioFilePath, $portfolioData)) {
+            $result = saveJsonFile($portfolioFilePath, $portfolioData);
+            if ($result['ok']) {
                 echo json_encode(['status' => 'success']);
             } else {
-                echo json_encode(['status' => 'error', 'message' => 'Kon volgorde niet opslaan.']);
+                echo json_encode(['status' => 'error', 'message' => 'Kon volgorde niet opslaan.', 'error' => $result['error']]);
             }
         } else {
             echo json_encode(['status' => 'error', 'message' => 'Ongeldige data.']);
@@ -761,10 +763,11 @@ case 'add_theme':
                 }
             }
             $portfolioData['themes'] = $reorderedThemes;
-            if (saveJsonFile($portfolioFilePath, $portfolioData)) {
+            $result = saveJsonFile($portfolioFilePath, $portfolioData);
+            if ($result['ok']) {
                 echo json_encode(['status' => 'success', 'message' => 'Portfolio volgorde opgeslagen.']);
             } else {
-                echo json_encode(['status' => 'error', 'message' => 'Kon volgorde niet opslaan.']);
+                echo json_encode(['status' => 'error', 'message' => 'Kon volgorde niet opslaan.', 'error' => $result['error']]);
             }
         } else {
             echo json_encode(['status' => 'error', 'message' => 'Ongeldige data.']);
@@ -870,10 +873,11 @@ case 'add_theme':
 
             if (count($newOrderedPhotos) === count($originalPhotos)) {
                 $galleryData['photos'] = $newOrderedPhotos;
-                if (saveJsonFile($galleryFile, $galleryData)) {
+                $result = saveJsonFile($galleryFile, $galleryData);
+                if ($result['ok']) {
                     echo json_encode(['status' => 'success']);
                 } else {
-                    echo json_encode(['status' => 'error', 'message' => 'Kon volgorde niet opslaan in bestand.']);
+                    echo json_encode(['status' => 'error', 'message' => 'Kon volgorde niet opslaan in bestand.', 'error' => $result['error']]);
                 }
             } else {
                 echo json_encode(['status' => 'error', 'message' => 'Fout in data, foto-aantallen komen niet overeen.']);

--- a/upload_ajax.php
+++ b/upload_ajax.php
@@ -56,7 +56,11 @@ switch ($target) {
         }
         $contentData[$section]['image'] = $paths['path'];
         $contentData[$section]['webp'] = $paths['webp'];
-        saveJsonFile($contentFile, $contentData);
+        $res = saveJsonFile($contentFile, $contentData);
+        if (!$res['ok']) {
+            echo json_encode(['status' => 'error', 'message' => 'Kon data niet opslaan.', 'error' => $res['error']]);
+            exit;
+        }
         echo json_encode(['status' => 'success', 'path' => $paths['path'], 'webp' => $paths['webp']]);
         exit;
 
@@ -90,7 +94,11 @@ switch ($target) {
             }
         }
         unset($m);
-        saveJsonFile($teamFile, $data);
+        $res = saveJsonFile($teamFile, $data);
+        if (!$res['ok']) {
+            echo json_encode(['status' => 'error', 'message' => 'Kon data niet opslaan.', 'error' => $res['error']]);
+            exit;
+        }
         echo json_encode(['status' => 'success', 'path' => $paths['path'], 'webp' => $paths['webp']]);
         exit;
 
@@ -105,7 +113,11 @@ switch ($target) {
         if (!isset($data['hero'])) $data['hero'] = [];
         $data['hero']['image'] = $paths['path'];
         $data['hero']['webp'] = $paths['webp'];
-        saveJsonFile($linksFile, $data);
+        $res = saveJsonFile($linksFile, $data);
+        if (!$res['ok']) {
+            echo json_encode(['status' => 'error', 'message' => 'Kon data niet opslaan.', 'error' => $res['error']]);
+            exit;
+        }
         echo json_encode(['status' => 'success', 'path' => $paths['path'], 'webp' => $paths['webp']]);
         exit;
 


### PR DESCRIPTION
## Summary
- Capture `file_put_contents` errors in `saveJsonFile` and return structured status
- Propagate save errors up to callers in `save.php` and `upload_ajax.php`

## Testing
- `php -l helpers.php save.php upload_ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9ed709ce08320bc75862d413b83ab